### PR TITLE
Feature/geo map output

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,5 @@ dependencies:
   - shinywidgets
   - plotly
   - anywidget
+  - altair
+  - ipywidgets

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - anywidget
   - altair
   - ipywidgets
+  - pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ plotly==6.5.2
 ipyleaflet==0.20.0
 altair==5.5.0
 ipywidgets==8.1.8
+pyproj==3.7.2
 
 # Utilities
 pyyaml==6.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ pandas==3.0.0
 numpy==2.4.2
 plotly==6.5.2
 ipyleaflet==0.20.0
+altair==5.5.0
+ipywidgets==8.1.8
 
 # Utilities
 pyyaml==6.0.3

--- a/src/app.py
+++ b/src/app.py
@@ -60,11 +60,8 @@ app_ui = ui.page_fluid(
             bg="#ffffff",
             open="desktop", 
         ),
-        ui.card(
-            "MAP: Interactive map of Vancouver with crime statistics visualised through circles. ",
-            "Changes according to selection. ",
-            "Optional display exact crime locations.",
-            output_widget("map"),
+        ui.card("Crime Map"),
+            output_widget("map")
         ),
         ui.layout_columns(
             ui.card(

--- a/src/app.py
+++ b/src/app.py
@@ -60,7 +60,7 @@ app_ui = ui.page_fluid(
             bg="#ffffff",
             open="desktop", 
         ),
-        ui.card("Crime Map"),
+        ui.card("Crime Map",
             output_widget("map")
         ),
         ui.layout_columns(

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,7 @@
-from ipyleaflet import Map  
+from ipyleaflet import Map, CircleMarker, Popup
+from ipywidgets import HTML
+import math
+from pyproj import Transformer
 from shiny import App, ui, reactive, render
 from shinywidgets import output_widget, render_widget  
 import plotly.express as px
@@ -88,7 +91,45 @@ app_ui = ui.page_fluid(
 def server(input, output, session):
     @render_widget  
     def map():
-        return Map(center=(49.25, -123.05), zoom=11)
+        df = filtered_data().copy()
+        df = df[(df['X'] != 0) & (df['Y'] != 0)]
+        map = Map(center=(49.25, -123.10), zoom=12)
+        
+        if df.empty:
+            return map
+        
+        neighbourhood_counts = df.groupby('NEIGHBOURHOOD').agg(
+            COUNT=('TYPE', 'count'),
+            X=('X', 'mean'),
+            Y=('Y', 'mean')).reset_index()
+
+        transformer = Transformer.from_crs("EPSG:32610", "EPSG:4326", always_xy=True)
+        neighbourhood_counts['LON'], neighbourhood_counts['LAT'] = transformer.transform(
+            neighbourhood_counts['X'].values,
+            neighbourhood_counts['Y'].values)
+
+        max_count = neighbourhood_counts['COUNT'].max()
+
+        for _, row in neighbourhood_counts.iterrows():
+            count = row['COUNT']
+            radius = int(5 + math.sqrt(count / max_count) * 50) if count > 0 else 5
+            
+            circle = CircleMarker(
+                location=(row['LAT'], row['LON']),
+                radius=radius,
+                color='steelblue',
+                fill_color='steelblue',
+                fill_opacity=0.4,
+                weight=1)
+            
+            circle.popup = Popup(
+                location=(row['LAT'], row['LON']),
+                child=HTML(value=f"<b>{row['NEIGHBOURHOOD']}</b><br>Total Crimes: {row['COUNT']}"),
+                close_button=True)
+
+            map.add(circle)
+
+        return map
     
     @reactive.calc
     def filtered_data():


### PR DESCRIPTION
PR addresses [#29](https://github.com/UBC-MDS/DSCI-532_2026_4_VanCrimeWatch/issues/29)

Here's what the map looks like so far:
<img width="1140" height="524" alt="Screenshot 2026-02-25 at 2 59 17 AM" src="https://github.com/user-attachments/assets/0c5552ae-5b3a-4310-ba29-0e238b4f1c0f" />

- Implemented interactive map that is fully linked to reactive df 
- Size of bubbles encodes number of crimes for easy comparison across neighborhoods
- Added click feature that shows neighborhood name + total crime count (hovering was hard to implement with ipyleaflet)
- one caveat is that using zoom=11 allows us to view all bubbles but is too far so size information gets lost, zoom=12 (used here) is more suitable but 'stanley park' bubble is not in frame, users would have to pan map upward to view it. Lmk if there any suggestions for this! 

**NOTE**: i filtered out points that had missing values for long/lat, but i did this within my map function. It might be a good idea for us to do this globally to ensure consistency of crime counts across all outputs. 