### PR TITLE
Feat/reset button

### DIFF
--- a/notebooks/VancouverCrimeAnalysis.ipynb
+++ b/notebooks/VancouverCrimeAnalysis.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 2,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-14T06:50:42.509914Z",
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 3,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-14T06:50:43.088182Z",
@@ -204,7 +204,7 @@
        "4  10XX PACIFIC ST      West End  490352.2816  5.458276e+06  "
       ]
      },
-     "execution_count": 27,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 4,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-14T06:50:43.187419Z",
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 5,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-14T06:50:43.209661Z",
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 6,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-02-14T06:50:43.219019Z",
@@ -338,6 +338,153 @@
     "    errors='coerce'\n",
     ")\n",
     "print('Date range:', df['DATE'].min(), 'to', df['DATE'].max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>TYPE</th>\n",
+       "      <th>YEAR</th>\n",
+       "      <th>MONTH</th>\n",
+       "      <th>DAY</th>\n",
+       "      <th>HOUR</th>\n",
+       "      <th>MINUTE</th>\n",
+       "      <th>HUNDRED_BLOCK</th>\n",
+       "      <th>NEIGHBOURHOOD</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "      <th>DATE</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2958</th>\n",
+       "      <td>Homicide</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>5</td>\n",
+       "      <td>27</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>OFFSET TO PROTECT PRIVACY</td>\n",
+       "      <td>West End</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2023-05-27</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2959</th>\n",
+       "      <td>Homicide</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>8</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>OFFSET TO PROTECT PRIVACY</td>\n",
+       "      <td>Central Business District</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2023-08-04</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2960</th>\n",
+       "      <td>Homicide</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>3</td>\n",
+       "      <td>26</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>OFFSET TO PROTECT PRIVACY</td>\n",
+       "      <td>Central Business District</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2023-03-26</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2961</th>\n",
+       "      <td>Homicide</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>9</td>\n",
+       "      <td>28</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>OFFSET TO PROTECT PRIVACY</td>\n",
+       "      <td>Central Business District</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2023-09-28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2962</th>\n",
+       "      <td>Homicide</td>\n",
+       "      <td>2023</td>\n",
+       "      <td>2</td>\n",
+       "      <td>6</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>OFFSET TO PROTECT PRIVACY</td>\n",
+       "      <td>Central Business District</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2023-02-06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          TYPE  YEAR  MONTH  DAY  HOUR  MINUTE              HUNDRED_BLOCK  \\\n",
+       "2958  Homicide  2023      5   27     0       0  OFFSET TO PROTECT PRIVACY   \n",
+       "2959  Homicide  2023      8    4     0       0  OFFSET TO PROTECT PRIVACY   \n",
+       "2960  Homicide  2023      3   26     0       0  OFFSET TO PROTECT PRIVACY   \n",
+       "2961  Homicide  2023      9   28     0       0  OFFSET TO PROTECT PRIVACY   \n",
+       "2962  Homicide  2023      2    6     0       0  OFFSET TO PROTECT PRIVACY   \n",
+       "\n",
+       "                  NEIGHBOURHOOD    X    Y       DATE  \n",
+       "2958                   West End  0.0  0.0 2023-05-27  \n",
+       "2959  Central Business District  0.0  0.0 2023-08-04  \n",
+       "2960  Central Business District  0.0  0.0 2023-03-26  \n",
+       "2961  Central Business District  0.0  0.0 2023-09-28  \n",
+       "2962  Central Business District  0.0  0.0 2023-02-06  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "homicides = df[df['TYPE'] == 'Homicide']\n",
+    "homicides.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: VPD Homicide information is sensitive. These records contain missing time and location data as seen above. As a result, these records will be excluded from map and hourly timeline visualizations."
    ]
   },
   {
@@ -1498,7 +1645,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "vancrimewatch",
    "language": "python",
    "name": "python3"
   },
@@ -1512,7 +1659,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/app.py
+++ b/src/app.py
@@ -72,6 +72,7 @@ app_ui = ui.page_fluid(
                 },
                 selected=["2023", "2024", "2025"], # default selects all the years
             ),
+            ui.input_action_button("reset_btn", "Reset Filters", class_="btn-success w-100"),
             title="Dashboard Filters",
             open="desktop", 
         ),
@@ -159,6 +160,14 @@ def server(input, output, session):
         return df
     
     render_kpis(output, input, filtered_data)
+
+    @reactive.effect
+    @reactive.event(input.reset_btn)
+    def reset_filters():
+        ui.update_selectize("input_neighbourhood", selected=[])
+        ui.update_selectize("input_crime_type", selected=[])
+        ui.update_checkbox_group("input_year", selected=["2023", "2024", "2025"])
+        ui.update_radio_buttons("time_display", selected="monthly")
     
     @render_altair  
     def donut_plot():  

--- a/src/kpi_cards.py
+++ b/src/kpi_cards.py
@@ -91,20 +91,27 @@ def render_kpis(output, input, filtered_data):
                 9: "September", 10: "October", 11: "November", 12: "December"
             }
             counts = df.groupby("MONTH").size()
-            peak = counts.idxmax()
+            if counts.empty:
+                return metric_col({"sub1": "", "value": "N/A", "sub2": "No data", "badge": "bg-secondary", "text": ""})
+            peak = month_names[counts.idxmax()]
             val = int(counts.max())
-            peak = month_names[peak]
+
         elif agg == "weekly":
             df = df.copy()
             df["weekday"] = pd.to_datetime(df[["YEAR", "MONTH", "DAY"]].rename(
                 columns={"YEAR": "year", "MONTH": "month", "DAY": "day"}
             )).dt.day_name()
             counts = df.groupby("weekday").size()
+            if counts.empty:
+                return metric_col({"sub1": "", "value": "N/A", "sub2": "No data", "badge": "bg-secondary", "text": ""})
             peak = counts.idxmax()
             val = int(counts.max())
+
         else:
             hourly_df = df[~((df["HOUR"] == 0) & (df["MINUTE"] == 0))]
             counts = hourly_df.groupby("HOUR").size().reset_index(name="count")
+            if counts.empty:
+                return metric_col({"sub1": "", "value": "N/A", "sub2": "No time data available", "badge": "bg-secondary", "text": ""})
             peak_idx = counts["count"].idxmax()
             peak_hour = counts.loc[peak_idx, "HOUR"]
             peak = f"{peak_hour}:00-{peak_hour + 1}:00"


### PR DESCRIPTION
 Addresses [#54](https://github.com/UBC-MDS/DSCI-532_2026_4_VanCrimeWatch/issues/54)
- Added reset button for UI filters, resorts to default selection when used.
- Bug fix: homicide data has hour, minute and location data omitted. To avoid KPI error, added empty data checks to KPI code. Made note of this in EDA as well.
