### PR TITLE
Fix/year selector

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -287,6 +287,18 @@ def server(input, output, session):
         ui.update_checkbox_group("input_year", selected=["2025"])
         ui.update_radio_buttons("time_display", selected="monthly")
 
+    @reactive.effect
+    def _enforce_year_selection():
+        selected_years = input.input_year()
+        
+        # Check if selected_years is empty (if the user deselected everything)
+        if not selected_years:
+            # Force the checkbox group back to a default value ("2025")
+            ui.update_checkbox_group("input_year", selected=["2025"])
+            
+            # Let the user know why their action was reversed
+            ui.notification_show("Please select at least one year.", type="warning", duration=3)
+
     @render.ui
     def ai_timeline_chart():
         df = qc_vals.df()

--- a/src/app.py
+++ b/src/app.py
@@ -269,8 +269,13 @@ def server(input, output, session):
         selected_neighbourhoods = list(input.input_neighbourhood())
 
         df = base_df
-        if selected_years:
-            df = df[df["YEAR"].astype(str).isin(selected_years)]
+
+        # If selected_year is empty, return an empty dataframe immediately 
+        if not selected_years:
+            return df.iloc[0:0]
+        
+        df = df[df["YEAR"].astype(str).isin(selected_years)]
+
         if selected_crimes:
             df = df[df["TYPE"].isin(selected_crimes)]
         if selected_neighbourhoods:

--- a/src/styles.css
+++ b/src/styles.css
@@ -123,12 +123,14 @@ body {
   border: 1px solid #3b5a8a;
 }
 
+[data-bs-theme="dark"] .btn-outline-secondary {
+  color: #dee2e6;
+  border-color: #6c757d;
+}
+
 /* Move Shiny notifications to the bottom left */
 #shiny-notification-panel {
     bottom: 20px;
     left: 20px;
     right: auto;
-[data-bs-theme="dark"] .btn-outline-secondary {
-  color: #dee2e6;
-  border-color: #6c757d;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -116,3 +116,10 @@ body {
   color: #8ab4f8;
   border: 1px solid #3b5a8a;
 }
+
+/* Move Shiny notifications to the bottom left */
+#shiny-notification-panel {
+    bottom: 20px;
+    left: 20px;
+    right: auto;
+}


### PR DESCRIPTION
Updated the year selection filter so that at least one year must always be selected. If the user deselects all the years, then the default year 2025 is automatically selected, and a warning is displayed. Addresses issue #88 

<img width="365" height="681" alt="image" src="https://github.com/user-attachments/assets/7a99d0bc-5195-44bd-9a1c-e3cd13d5a152" />


- Added `_enforce_year_selection()` helper function in server
- Added CSS to specify the warning location to be at the bottom left of the screen
- Updated filter logic so it displays zero records for a split second while the effect takes place to forces the selection back to the default 2025 (instead of showing all years selected)