### PR TITLE
enhancements/responsive-charts

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -134,11 +134,11 @@ dashboard_tab = ui.nav_panel(
         ui.layout_columns(
             ui.card(
                 get_card_header("Types of Crime", icon="Hover"),
-                output_widget("donut_plot"),
+                ui.output_ui("donut_plot"),
             ),
             ui.card(
                 get_card_header("Crime Timeline", icon="Hover"),
-                output_widget("timeline_chart"),
+                ui.output_ui("timeline_chart"),
             ),
         ),
         fillable_mobile=True,
@@ -228,7 +228,10 @@ app_ui = ui.page_navbar(
         ui.h1("VanCrimeWatch", class_="mb-0 fs-4 text-white"),
         class_="d-flex align-items-center",
     ),
-    header=ui.include_css(appdir.parent / "src" / "styles.css"),
+    header=ui.TagList(
+        ui.include_css(appdir.parent / "src" / "styles.css"),
+        ui.tags.script(src="https://cdn.plot.ly/plotly-2.35.2.min.js"),
+    ),
     navbar_options=ui.navbar_options(
         theme="dark",
         class_="bg-primary text-white p-4 mb-0 d-flex justify-content-between align-items-center",
@@ -261,13 +264,14 @@ def server(input, output, session):
         fig = _make_donut_plot(df, input, compact=True)
         return ui.HTML(
             fig.to_html(
-                full_html=False, include_plotlyjs="cdn", config={"responsive": True}
+                full_html=False, include_plotlyjs=False, config={"responsive": True}
             )
         )
 
-    @render_widget
+    @render.ui
     def donut_plot():
-        return _make_donut_plot(filtered_data(), input)
+        fig = _make_donut_plot(filtered_data(), input)
+        return ui.HTML(fig.to_html(full_html=False, include_plotlyjs=False, config={"responsive": True}))
 
     @render_widget
     def ai_map():
@@ -337,13 +341,14 @@ def server(input, output, session):
         fig = _make_timeline_chart(df, input, compact=True)
         return ui.HTML(
             fig.to_html(
-                full_html=False, include_plotlyjs="cdn", config={"responsive": True}
+                full_html=False, include_plotlyjs=False, config={"responsive": True}
             )
         )
 
-    @render_widget
+    @render.ui
     def timeline_chart():
-        return _make_timeline_chart(filtered_data(), input)
+        fig = _make_timeline_chart(filtered_data(), input)
+        return ui.HTML(fig.to_html(full_html=False, include_plotlyjs="cdn", config={"responsive": True}))
 
 
 app = App(app_ui, server)

--- a/src/donut_chart.py
+++ b/src/donut_chart.py
@@ -43,10 +43,10 @@ def _make_donut_plot(df, input, compact=False):
         domain=dict(x=[0, chart_domain])  # reserve space on the right for legend
     )
     fig.update_layout(
+        autosize=True,
         plot_bgcolor="rgba(0,0,0,0)",
         paper_bgcolor="rgba(0,0,0,0)",
         height=300 if compact else 370,
-        width=450 if compact else 550,
         margin=dict(t=10, b=10, l=0, r=100),
         legend=dict(
             title=None,

--- a/src/styles.css
+++ b/src/styles.css
@@ -10,8 +10,8 @@ body {
 
 /* Increase font size for navbar tab titles */
 .navbar-nav .nav-link {
-    font-size: 1.1rem;
-    font-weight: 500;
+  font-size: 1.1rem;
+  font-weight: 500;
 }
 
 .bslib-value-box .plotly .modebar-container {
@@ -69,20 +69,20 @@ body {
 }
 
 [data-bs-theme="dark"] .shiny-data-grid thead th {
-    background-color: #1e1e2e !important;
-    color: #ffffff !important;
+  background-color: #1e1e2e !important;
+  color: #ffffff !important;
 }
 
 [data-bs-theme="dark"] .shiny-data-grid tbody tr.selected,
 [data-bs-theme="dark"] .shiny-data-grid tbody tr:focus,
 [data-bs-theme="dark"] .shiny-data-grid tbody tr[aria-selected="true"] {
-    background-color: #3a3a5c !important;
-    color: #ffffff !important;
+  background-color: #3a3a5c !important;
+  color: #ffffff !important;
 }
 
 [data-bs-theme="dark"] .shiny-data-grid tbody tr:hover {
-    background-color: #2a2a3e !important;
-    color: #ffffff !important;
+  background-color: #2a2a3e !important;
+  color: #ffffff !important;
 }
 
 .tab-pane:nth-child(2) .bslib-sidebar-layout>.sidebar {
@@ -93,6 +93,14 @@ body {
 .tab-pane:nth-child(2) .bslib-sidebar-layout>.main {
   max-height: calc(100vh - 120px);
   overflow-y: auto;
+}
+
+@media (max-width: 767px) {
+
+  .tab-pane:nth-child(2) .bslib-sidebar-layout>.sidebar,
+  .tab-pane:nth-child(2) .bslib-sidebar-layout>.main {
+    max-height: none;
+  }
 }
 
 /* fixed height within sidebar */
@@ -130,7 +138,7 @@ body {
 
 /* Move Shiny notifications to the bottom left */
 #shiny-notification-panel {
-    bottom: 20px;
-    left: 20px;
-    right: auto;
+  bottom: 20px;
+  left: 20px;
+  right: auto;
 }


### PR DESCRIPTION
Issue #102 
Responsive Charts for all device forms:
- Switch Dashboard donut & timeline from output_widget to ui.output_ui with to_html(responsive=True)
- Remove fixed width from donut chart (both compact and non-compact modes)
- Load Plotly CDN once in page header to prevent race condition
- Add mobile media query to remove max-height on AI Explorer tab