### PR TITLE
critical feedback: feat/ai-missing-data-message

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -259,7 +259,7 @@ def server(input, output, session):
         df = qc_vals.df()
         df = df.to_native() if hasattr(df, "to_native") else df
         if df.empty:
-            return ui.p("No data found for your query. The crime type you are searching for has no records, " \
+            return ui.p("No data found for your query. The crime type you are searching for has no records or does not exist, " \
                         "Try rephrasing or broadening your search.",
                     style="color: #6c757d; text-align: center; padding: 40px;")
         fig = _make_donut_plot(df, input, compact=True)

--- a/src/app.py
+++ b/src/app.py
@@ -258,6 +258,10 @@ def server(input, output, session):
     def ai_donut_plot():
         df = qc_vals.df()
         df = df.to_native() if hasattr(df, "to_native") else df
+        if df.empty:
+            return ui.p("No data found for your query. The crime type you are searching for has no records, " \
+                        "Try rephrasing or broadening your search.",
+                    style="color: #6c757d; text-align: center; padding: 40px;")
         fig = _make_donut_plot(df, input, compact=True)
         return ui.HTML(
             fig.to_html(
@@ -334,6 +338,10 @@ def server(input, output, session):
     def ai_timeline_chart():
         df = qc_vals.df()
         df = df.to_native() if hasattr(df, "to_native") else df
+        if df.empty:
+            return ui.p("No data found for your query. Only data from the years 2023, 2024 and 2025 exist in our records." \
+                        " Try rephrasing or broadening your search.",
+                    style="color: #6c757d; text-align: center; padding: 40px;")
         fig = _make_timeline_chart(df, input, compact=True)
         return ui.HTML(
             fig.to_html(


### PR DESCRIPTION
Closes [#93](https://github.com/UBC-MDS/DSCI-532_2026_4_VanCrimeWatch/issues/92)

- Querychat feature: added informative message to donut chart + timeline chart for cases when query might return no data/when no records are present that match the user's query. 

For example(see image below): 'show me homicides in kitsilano from 2025'. Since no homicides have been recorded in this neighborhood in the year 2025, the charts display a message + map is returned empty 

Also good for overly-specific queries that fail to produce any filtered data, example: 'show me vandalism crimes in Kitsilano in January 2024 at 3am'

<img width="1435" height="815" alt="Screenshot 2026-03-16 at 12 34 36 AM" src="https://github.com/user-attachments/assets/7fd3e30e-6ba1-4901-9f6b-8fe6c7c5c4b7" />
