### PR TITLE
added kpi for most crime types

### DIFF
--- a/src/kpi_cards.py
+++ b/src/kpi_cards.py
@@ -82,6 +82,25 @@ def render_kpis(output, input, filtered_data):
             "badge": "bg-info",
             "text": "text-dark",
         })
+    
+    @output
+    @render.ui
+    def unsafe_block():
+        """Output widget for most crime neighbourhood"""
+        df = filtered_data()
+        if df.empty:
+            return metric_col({"sub1": "", "value": "N/A", "sub2": "No data", "badge": "bg-secondary", "text": ""})
+        block_counts = df['NEIGHBOURHOOD'].value_counts()
+        busiest = block_counts.idxmax()
+        count = int(block_counts.max())
+        pct = round(count / len(df) * 100, 1)
+        return metric_col({
+            "sub1": f"{count:,}",
+            "value": busiest,
+            "sub2": f"{pct}% of total",
+            "badge": "bg-danger",
+            "text": "",
+        })
 
     @output
     @render.ui
@@ -149,8 +168,9 @@ def render_card(title, block, cols):
 def kpi_card_widget():
     """Main widget to collect and display all KPIs"""
     card_details = [
-        ("Least Crime", ui.output_ui("safest_block"), 3),
-        ("Peak Crime Time", ui.output_ui("peak_crime_period"), 3),
+        ("Least Crime", ui.output_ui("safest_block"), 2),
+        ("Most Crime", ui.output_ui("unsafe_block"), 2),
+        ("Peak Crime Time", ui.output_ui("peak_crime_period"), 2),
         ("Total Crimes by Year", ui.output_ui("metrics_row"), 6)
     ]
     return ui.div(


### PR DESCRIPTION
Closes [#93](https://github.com/UBC-MDS/DSCI-532_2026_4_VanCrimeWatch/issues/93)

- added kpi for neighborhood with 'most crime'. I experimented with the size of the kpis to have them all fit on the same row. Do we think this looks too cluttered? 

<img width="1429" height="695" alt="Screenshot 2026-03-16 at 1 17 18 AM" src="https://github.com/user-attachments/assets/d1ad531d-f692-4054-ba2c-8e17eadda290" />

- Also, i played around with the color encoding of the bubbles in the map, i think color coding by crime density is redundant since size of bubbles + the kpis already communicate low crime areas vs high crime areas. Also, i didn't love the look of a multi-colored map, but let me know if you guys disagree. 

<img width="1429" height="550" alt="Screenshot 2026-03-16 at 1 35 14 AM" src="https://github.com/user-attachments/assets/f7fd932c-9949-4e37-8be1-cb0bcf2ab793" />
